### PR TITLE
Interrupts for PCF8574 and MCP230xx, Input Fix for PCF8574

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Communicates with devices connected to the local system using the I2C bus.
 
-This adapter should work on Linux boards like the Raspberry Pi, C.H.I.P., BeagleBone or Intel Edison. 
+This adapter should work on Linux boards like the Raspberry Pi, C.H.I.P., BeagleBone or Intel Edison.
 
 ## Install
 
@@ -74,6 +74,10 @@ Texas Instruments Remote 8-Bit I/O Expander for I2C Bus.
 ### PCF8574A 8-Bit I/O Expander (38-3F)
 
 Texas Instruments Remote 8-Bit I/O Expander for I2C Bus.
+
+### Generic device (03-77)
+
+Generic I2C device. Registers can be configured depending on the hardware.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,40 @@ Texas Instruments Remote 8-Bit I/O Expander for I2C Bus.
 
 Generic I2C device. Registers can be configured depending on the hardware.
 
+## Usage in scripts
+
+Supported commands for `sendTo` in scripts are `search`, `read` and `write`.
+
+`search` takes as message the bus number and returns a JSON string of an array of found addresses on the bus.
+
+`read` takes as message an object containing the address and optional the register and number of bytes to read. It returns a buffer with the read data.
+
+`write` takes as message an object containing the address, the data as buffer and optional the register to write. It returns the written buffer on success.
+
+### Examples for script usage
+
+```js
+sendTo('i2c.0', 'search', 1, (ret) => {
+    log('Ret: ' + ret, 'info');
+});
+
+sendTo('i2c.0', 'read', {
+    address: 0x40,
+    register: 0x02,
+    bytes: 2
+}, (ret) => {
+    log('Ret: ' + ret.inspect(), 'info');
+});
+
+sendTo('i2c.0', 'write', {
+    address: 0x40,
+    register: 0x00,
+    data: Buffer.from([0x44, 0x27])
+}, (ret) => {
+    log('Ret: ' + ret.inspect(), 'info');
+});
+```
+
 ## Compatibility
 
 Compatibility has been tested with Raspberry Pi 3.
@@ -93,6 +127,13 @@ If you require a missing devcies, please provide the type of IC (brand, model, .
 * Support interrupts instead of only polling for MCP230xx and PCF8574
 
 ## Changelog
+
+### 0.0.8 (2020-05-26)
+* (Peter Müller) Added support for Generic device.
+* (Peter Müller) Added support for `read` and `write` commands in scripts using `sendTo`.
+
+### 0.0.7 (2019-07-29)
+* (Peter Müller) Added support for interrupts on PCF8574, MCP23008, MCP23017 devices.
 
 ### 0.0.6 (2019-03-17)
 * (UncleSamSwiss) Added support for BME280.

--- a/admin/devices/Generic.js
+++ b/admin/devices/Generic.js
@@ -1,0 +1,109 @@
+﻿function Generic() {
+    DeviceBase.call(this, 'Generic');
+
+    for (var i = 3; i <= 119; i++) {
+        this.addresses.push(i);
+    }
+
+    this.template = '<tr><td><label for="{{:#parent.parent.data.address}}-name">{{t:"Name"}}</label></td><td class="admin-icon"></td>';
+    this.template += '<td><input type="text" id="{{:#parent.parent.data.address}}-name" data-link="Generic.name" /></td></tr>';
+    this.template += '<tr><th>{{t:"Register"}}</th><th class="admin-icon"></th>';
+    this.template += '<th>{{t:"Name"}}</th>';
+    this.template += '<th>{{t:"Data type"}}</th>';
+    this.template += '<th>{{t:"Read"}}</th>';
+    this.template += '<th>{{t:"Write"}}</th>';
+    this.template += '<th>{{t:"Polling Interval (ms)"}}</th></tr>';
+
+    this.template += '{^{for Generic.registers}}';
+    this.template += '<tr><td><select data-link="{:register:strToInt}">';
+    this.template += '<option value="-1">---</option>';
+    for (var i = 0; i<= 255; i++) {
+      this.template += '<option value="' + i + '">' + this.toHexString(i) + '</option>';
+    }
+    this.template += '</select></td><th class="admin-icon"></th>';
+    this.template += '<td><input type="text" id="{{:#parent.parent.data.address}}-name-{{:#index}}" data-link="name" /></td>';
+    this.template += '<td><select id="{{:#parent.parent.data.address}}-type-{{:#index}}" data-link="type">';
+    this.template += '<option value="int8">int8</option>';
+    this.template += '<option value="uint8">uint8</option>';
+    this.template += '<option value="int16_be">int16_be</option>';
+    this.template += '<option value="int16_le">int16_le</option>';
+    this.template += '<option value="uint16_be">uint16_be</option>';
+    this.template += '<option value="uint16_le">uint16_le</option>';
+    this.template += '<option value="int32_be">int32_be</option>';
+    this.template += '<option value="int32_le">int32_le</option>';
+    this.template += '<option value="uint32_be">uint32_be</option>';
+    this.template += '<option value="uint32_le">uint32_le</option>';
+    this.template += '<option value="float_be">float_be</option>';
+    this.template += '<option value="float_le">float_le</option>';
+    this.template += '<option value="double_be">double_be</option>';
+    this.template += '<option value="double_le">double_le</option>';
+    this.template += '</select></td>';
+    this.template += '<td><input type="checkbox" id="{{:#parent.parent.data.address}}-read-{{:#index}}" data-link="read" /></td>';
+    this.template += '<td><input type="checkbox" id="{{:#parent.parent.data.address}}-write-{{:#index}}" data-link="write" /></td>';
+    this.template += '<td>{^{if read}}<input type="text" id="{{:#parent.parent.data.address}}-pollingInterval-{{:#index}}" data-link="{:pollingInterval:strToInt}" />{{/if}}</td>';
+    this.template += '<td><button data-link="{on #parent.parent.data.removeRegister #index}"><i class="material-icons">delete_forever</i></button></td></tr>';
+    this.template += '{{/for}}';
+
+    this.template += '<tr><td><button data-link="{on addRegister}"><i class="material-icons">add_circle_outline</i></button></td></tr>';
+}
+
+$.views.converters({
+  strToInt: function(value) {
+    return parseInt(value);
+  }
+});
+
+Generic.prototype = Object.create(DeviceBase.prototype);
+Generic.prototype.constructor = Generic;
+
+Generic.prototype.toHexString = function (integer) {
+  var str = parseInt(integer).toString(16);
+  return '0x' + (str.length == 1 ? '0' + str : str);
+}
+
+Generic.prototype.prepareViewModel = function (device) {
+    device.Generic = device.Generic || {};
+    device.Generic.name = device.Generic.name || _('Generic device');
+    device.Generic.registers = device.Generic.registers || [];
+
+    device.addRegister = function() {
+      $.observable(this.Generic.registers).insert({
+        register: -1,
+        name: '',
+        type: 'uint8',
+        read: true,
+        write: false,
+        pollingInterval: 1000
+      });
+    }
+
+    device.removeRegister = function (index) {
+      $.observable(this.Generic.registers).remove(index);
+    }
+
+    return device;
+};
+
+Generic.prototype.prepareModel = function (device) {
+    device.name = this.name;
+
+    console.log(device);
+    return device;
+};
+
+// "exports" of all device types supported by this class
+deviceTypes.Generic = new Generic();
+
+// translations
+systemDictionary['Name'] = {
+  "en": "Name",
+  "de": "Name"
+};
+systemDictionary['Register'] = {
+  "en": "Register",
+  "de": "Register"
+};
+systemDictionary['Data type'] = {
+  "en": "Data type",
+  "de": "Datentyp"
+};

--- a/admin/devices/MCP23008.js
+++ b/admin/devices/MCP23008.js
@@ -1,13 +1,15 @@
 ﻿function MCP23008() {
     DeviceBase.call(this, 'MCP23008');
-    
+
     var baseAddress = 0x20;
     for (var i = 0; i < 8; i++) {
         this.addresses.push(baseAddress + i);
     }
-    
+
     this.template = '<tr><td><label for="{{:#parent.parent.data.address}}-pollingInterval">{{t:"Polling Interval (ms)"}}</label></td><td class="admin-icon"></td>';
     this.template += '<td><input type="text" id="{{:#parent.parent.data.address}}-pollingInterval" data-link="MCP23008.pollingInterval" /></td></tr>';
+    this.template += '<tr><td><label for="{{:#parent.parent.data.address}}-interrupt">{{t:"Interrupt object"}}</label></td><td class="admin-icon"></td>';
+    this.template += '<td><input type="text" id="{{:#parent.parent.data.address}}-interrupt" data-link="MCP23008.interrupt" /><button class="select-id" data-select-for="{{:#parent.parent.data.address}}-interrupt"><i class="material-icons">add_circle_outline</i><span></span></button></td></tr>';
     this.template += '{^{for MCP23008.pins}}';
     this.template += '<tr><td><label for="{{:#parent.parent.data.address}}-pin-{{:#index}}">{{t:"Pin"}} {{:#index}}</label></td><td class="admin-icon"></td>';
     this.template += '<td><select data-link="dir" id="{{:#parent.parent.data.address}}-pin-{{:#index}}">';
@@ -26,6 +28,7 @@ MCP23008.prototype.constructor = MCP23008;
 MCP23008.prototype.prepareViewModel = function (device) {
     device.MCP23008 = device.MCP23008 || {};
     device.MCP23008.pollingInterval = device.MCP23008.pollingInterval || 200;
+    device.MCP23008.interrupt = device.MCP23008.interrupt || '';
     device.MCP23008.pins = device.MCP23008.pins || [];
     for (var i = 0; i < 8; i++) {
         if (!device.MCP23008.pins[i]) {
@@ -39,6 +42,7 @@ MCP23008.prototype.prepareViewModel = function (device) {
 };
 
 MCP23008.prototype.prepareModel = function (device) {
+    device.MCP23008.interrupt = $('#' + device.address + '-interrupt').val(); // needed to fix (sometimes) invalid value
     device.name = this.name;
     return device;
 };
@@ -70,4 +74,8 @@ systemDictionary['Output'] = {
 systemDictionary['inverted'] = {
     "en": "inverted",
     "de": "invertiert"
+};
+systemDictionary['Interrupt object'] = {
+    "en": "Interrupt object",
+    "de": "Interrupt-Objekt"
 };

--- a/admin/devices/MCP23017.js
+++ b/admin/devices/MCP23017.js
@@ -1,13 +1,15 @@
 ﻿function MCP23017() {
     DeviceBase.call(this, 'MCP23017');
-    
+
     var baseAddress = 0x20;
     for (var i = 0; i < 8; i++) {
         this.addresses.push(baseAddress + i);
     }
-    
+
     this.template = '<tr><td><label for="{{:#parent.parent.data.address}}-pollingInterval">{{t:"Polling Interval (ms)"}}</label></td><td class="admin-icon"></td>';
     this.template += '<td><input type="text" id="{{:#parent.parent.data.address}}-pollingInterval" data-link="MCP23017.pollingInterval" /></td></tr>';
+    this.template += '<tr><td><label for="{{:#parent.parent.data.address}}-interrupt">{{t:"Interrupt object"}}</label></td><td class="admin-icon"></td>';
+    this.template += '<td><input type="text" id="{{:#parent.parent.data.address}}-interrupt" data-link="MCP23017.interrupt" /><button class="select-id" data-select-for="{{:#parent.parent.data.address}}-interrupt"><i class="material-icons">add_circle_outline</i><span></span></button></td></tr>';
     this.template += '{^{for MCP23017.pins}}';
     this.template += '<tr><td><label for="{{:#parent.parent.data.address}}-pin-{{:#index}}">{{t:"Pin"}} {{:name}}</label></td><td class="admin-icon"></td>';
     this.template += '<td><select data-link="dir" id="{{:#parent.parent.data.address}}-pin-{{:#index}}">';
@@ -26,6 +28,7 @@ MCP23017.prototype.constructor = MCP23017;
 MCP23017.prototype.prepareViewModel = function (device) {
     device.MCP23017 = device.MCP23017 || {};
     device.MCP23017.pollingInterval = device.MCP23017.pollingInterval || 200;
+    device.MCP23017.interrupt = device.MCP23017.interrupt || '';
     device.MCP23017.pins = device.MCP23017.pins || [];
     for (var i = 0; i < 16; i++) {
         if (!device.MCP23017.pins[i]) {
@@ -40,6 +43,7 @@ MCP23017.prototype.prepareViewModel = function (device) {
 };
 
 MCP23017.prototype.prepareModel = function (device) {
+    device.MCP23017.interrupt = $('#' + device.address + '-interrupt').val(); // needed to fix (sometimes) invalid value
     device.name = this.name;
     return device;
 };
@@ -71,4 +75,8 @@ systemDictionary['Output'] = {
 systemDictionary['inverted'] = {
     "en": "inverted",
     "de": "invertiert"
+};
+systemDictionary['Interrupt object'] = {
+    "en": "Interrupt object",
+    "de": "Interrupt-Objekt"
 };

--- a/admin/devices/PCF8574.js
+++ b/admin/devices/PCF8574.js
@@ -4,9 +4,11 @@
     for (var i = 0; i < 8; i++) {
         this.addresses.push(baseAddress + i);
     }
-    
+
     this.template = '<tr><td><label for="{{:#parent.parent.data.address}}-pollingInterval">{{t:"Polling Interval (ms)"}}</label></td><td class="admin-icon"></td>';
     this.template += '<td><input type="text" id="{{:#parent.parent.data.address}}-pollingInterval" data-link="PCF8574.pollingInterval" /></td></tr>';
+    this.template += '<tr><td><label for="{{:#parent.parent.data.address}}-interrupt">{{t:"Interrupt object"}}</label></td><td class="admin-icon"></td>';
+    this.template += '<td><input type="text" id="{{:#parent.parent.data.address}}-interrupt" data-link="PCF8574.interrupt" /><button class="select-id" data-select-for="{{:#parent.parent.data.address}}-interrupt"><i class="material-icons">add_circle_outline</i><span></span></button></td></tr>';
     this.template += '{^{for PCF8574.pins}}';
     this.template += '<tr><td><label for="{{:#parent.parent.data.address}}-pin-{{:#index}}">{{t:"Pin"}} {{:#index}}</label></td><td class="admin-icon"></td>';
     this.template += '<td><select data-link="dir" id="{{:#parent.parent.data.address}}-pin-{{:#index}}">';
@@ -24,6 +26,7 @@ PCF8574.prototype.constructor = PCF8574;
 PCF8574.prototype.prepareViewModel = function (device) {
     device.PCF8574 = device.PCF8574 || {};
     device.PCF8574.pollingInterval = device.PCF8574.pollingInterval || 200;
+    device.PCF8574.interrupt = device.PCF8574.interrupt || '';
     device.PCF8574.pins = device.PCF8574.pins || [];
     for (var i = 0; i < 8; i++) {
         if (!device.PCF8574.pins[i]) {
@@ -37,6 +40,7 @@ PCF8574.prototype.prepareViewModel = function (device) {
 };
 
 PCF8574.prototype.prepareModel = function (device) {
+    device.PCF8574.interrupt = $('#' + device.address + '-interrupt').val(); // needed to fix (sometimes) invalid value
     device.name = this.name;
     return device;
 };
@@ -65,4 +69,8 @@ systemDictionary['Output'] = {
 systemDictionary['inverted'] = {
     "en": "inverted",
     "de": "invertiert"
+};
+systemDictionary['Interrupt object'] = {
+    "en": "Interrupt object",
+    "de": "Interrupt-Objekt"
 };

--- a/admin/index.html
+++ b/admin/index.html
@@ -13,6 +13,11 @@
     <script type="text/javascript" src="lib/js/jsviews-jqueryui-widgets.min.js"></script>
     <script type="text/javascript" src="words.js"></script>
 
+    <link rel="stylesheet" type="text/css" href="../../lib/css/fancytree/ui.fancytree.min.css"/>
+    <link rel="stylesheet" type="text/css" href="../../lib/css/iob/selectID.css"/>
+    <script type="text/javascript" src="../../lib/js/jquery.fancytree-all.min.js"></script>
+    <script type="text/javascript" src="../../lib/js/selectID.js"></script>
+
     <!-- supported devices -->
     <script type="text/javascript" src="devices/DeviceBase.js"></script> <!-- this must come before all other devices -->
     <script type="text/javascript" src="devices/PCF8574.js"></script>
@@ -126,6 +131,43 @@
             return '0x' + (str.length == 1 ? '0' + str : str);
         }
 
+        var selectId;
+        function initSelectId(callback) {
+            if (selectId) {
+                return callback(selectId);
+            }
+            socket.emit('getObjects', function (err, objs) {
+                selectId = $('#dialog-select-member').selectId('init',  {
+                    noMultiselect: true,
+                    objects: objs,
+                    imgPath:       '../../lib/css/fancytree/',
+                    filter:        {type: 'state'},
+                    name:          'i2c-select-state',
+                    texts: {
+                        select:          _('Select'),
+                        cancel:          _('Cancel'),
+                        all:             _('All'),
+                        id:              _('ID'),
+                        name:            _('Name'),
+                        role:            _('Role'),
+                        room:            _('Room'),
+                        value:           _('Value'),
+                        selectid:        _('Select ID'),
+                        from:            _('From'),
+                        lc:              _('Last changed'),
+                        ts:              _('Time stamp'),
+                        wait:            _('Processing...'),
+                        ack:             _('Acknowledged'),
+                        selectAll:       _('Select all'),
+                        unselectAll:     _('Deselect all'),
+                        invertSelection: _('Invert selection')
+                    },
+                    columns: ['image', 'name', 'role', 'room']
+                });
+                callback(selectId);
+            });
+        }
+
         // the function loadSettings has to exist ...
         function load(settings, onChange) {
             // prepare the view model
@@ -176,6 +218,18 @@
                     $('#search').button('enable');
                 });
             });
+
+            $('.select-id').button().click(function (evt) {
+                initSelectId(function (sid) {
+                    var $elem = $('#' + $(evt.target).closest('button').data('select-for'));
+                    sid.selectId('show', $elem.val(), function (newId) {
+                        if (newId != $elem.val()) {
+                            $elem.val(newId);
+                            onChange();
+                        }
+                    });
+                });
+            });
         }
 
         // ... and the function save has to exist.
@@ -220,6 +274,23 @@
         <table><tr><td><img src="i2c.png" width="64" height="64"></td><td><h3 class="translate">I²C adapter settings</h3></td></tr></table>
 
         <div id="content"></div>
+    </div>
+
+    <div class="m material-dialogs">
+        <div id="dialog-select-member" class="modal modal-fixed-footer">
+            <div class="modal-content">
+                <div class="row">
+                    <div class="col s12 title"></div>
+                </div>
+                <div class="row">
+                    <div class="col s12 dialog-content"></div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <a class="modal-action modal-close waves-effect waves-green btn btn-set"><i class="large material-icons left">check</i><span class="translate">Select</span></a>
+                <a class="modal-action modal-close waves-effect waves-green btn btn-close"><i class="large material-icons left ">close</i><span class="translate">Cancel</span></a>
+            </div>
+        </div>
     </div>
 </body>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -25,6 +25,7 @@
     <script type="text/javascript" src="devices/MCP23017.js"></script>
     <script type="text/javascript" src="devices/BME280.js"></script>
     <script type="text/javascript" src="devices/ADS1x15.js"></script>
+    <script type="text/javascript" src="devices/Generic.js"></script>
 
     <!-- converters for JsRender -->
     <script type="text/javascript">

--- a/devices/Generic.js
+++ b/devices/Generic.js
@@ -1,0 +1,320 @@
+/*
+ * Generic I2C device.
+ *
+ * Copyright (C) 2020 Peter Müller <peter@crycode.de> (https://crycode.de)
+ */
+"use strict";
+
+function create(deviceConfig, i2cAdapter) {
+  return new Generic(deviceConfig, i2cAdapter);
+}
+
+function Generic(deviceConfig, i2cAdapter) {
+  this.address = deviceConfig.address;
+  this.name = deviceConfig.Generic.name || deviceConfig.name || 'Generic';
+  this.hexAddress = i2cAdapter.toHexString(this.address);
+
+  this.config = deviceConfig.Generic;
+
+  this.i2cAdapter = i2cAdapter;
+  this.adapter = this.i2cAdapter.adapter;
+
+  this.timers = [];
+}
+
+Generic.prototype.start = function () {
+  var that = this;
+  that.debug('Starting');
+  that.adapter.extendObject(that.hexAddress, {
+      type: 'device',
+      common: {
+          name: this.hexAddress + ' (' + this.name + ')',
+          role: 'sensor'
+      },
+      native: that.config
+  });
+
+  for (var i = 0; i < that.config.registers.length; i++) {
+    that.config.registers[i].registerHex = that.i2cAdapter.toHexString(that.config.registers[i].register);
+    that.config.registers[i].read = !!that.config.registers[i].read; // make it definetly boolean
+    that.config.registers[i].write = !!that.config.registers[i].write; // make it definetly boolean
+
+    that.debug('Register ' + that.config.registers[i].registerHex + ' ' + JSON.stringify(that.config.registers[i]));
+
+    that.adapter.extendObject(that.hexAddress + '.' + that.config.registers[i].registerHex, {
+      type: 'state',
+      common: {
+        name: that.hexAddress + ' ' + (that.config.registers[i].name || 'Register'),
+        read: that.config.registers[i].read,
+        write: that.config.registers[i].write,
+        type: 'number',
+        role: 'value'
+      },
+      native: that.config.registers[i]
+    });
+
+    // init polling when read
+    if (that.config.registers[i].read) {
+      that.poll(that.config.registers[i]);
+
+      if (that.config.registers[i].pollingInterval > 0) {
+        that.initPolling(that.config.registers[i]);
+      }
+    }
+
+    // init listener when write
+    if (that.config.registers[i].write) {
+      // send current value on startup for write only regsiters
+      if (!that.config.registers[i].read) {
+        var value = that.getStateValue(that.config.registers[i]);
+        if (typeof value === 'number') {
+          that.sendValue(that.config.registers[i], value);
+        }
+      }
+
+      that.addOutputListener(that.config.registers[i]);
+    }
+  }
+};
+
+Generic.prototype.stop = function () {
+  this.debug('Stopping');
+  for (var i = 0; i < this.timers.length; i++) {
+    clearInterval(this.timers[i]);
+  }
+};
+
+Generic.prototype.addOutputListener = function (registerObj) {
+  var that = this;
+  that.i2cAdapter.addStateChangeListener(that.hexAddress + '.' + registerObj.registerHex, function (oldValue, newValue) {
+    that.sendValue(registerObj, newValue);
+  });
+};
+
+Generic.prototype.sendValue = function (registerObj, value) {
+  var buf;
+  try {
+    switch (registerObj.type) {
+      case 'int8':
+        buf = Buffer.alloc(1);
+        buf.writeInt8(value);
+        break;
+      case 'uint8':
+        buf = Buffer.alloc(1);
+        buf.writeUInt8(value);
+        break;
+      case 'int16_be':
+        buf = Buffer.alloc(2);
+        buf.writeInt16BE(value);
+        break;
+      case 'int16_le':
+        buf = Buffer.alloc(2);
+        buf.writeInt16LE(value);
+        break;
+      case 'uint16_be':
+        buf = Buffer.alloc(2);
+        buf.writeUInt16BE(value);
+        break;
+      case 'uint16_le':
+        buf = Buffer.alloc(2);
+        buf.writeUInt16LE(value);
+        break;
+      case 'int32_be':
+        buf = Buffer.alloc(4);
+        buf.writeInt32BE(value);
+        break;
+      case 'int32_le':
+        buf = Buffer.alloc(4);
+        buf.writeInt32LE(value);
+        break;
+      case 'uint32_be':
+        buf = Buffer.alloc(4);
+        buf.writeUInt32BE(value);
+        break;
+      case 'uint32_le':
+        buf = Buffer.alloc(4);
+        buf.writeUInt32LE(value);
+        break;
+      case 'float_be':
+        buf = Buffer.alloc(4);
+        buf.writeFloatBE(value);
+        break;
+      case 'float_le':
+        buf = Buffer.alloc(4);
+        buf.writeFloatLE(value);
+        break;
+      case 'double_be':
+        buf = Buffer.alloc(8);
+        buf.writeDoubleBE(value);
+        break;
+      case 'double_le':
+        buf = Buffer.alloc(8);
+        buf.writeDoubleLE(value);
+        break;
+      default:
+        this.error('Couldn\'t send value because of unknown type: ' + registerObj.type);
+        return;
+    }
+  } catch (e) {
+    this.error('Couldn\'t send value because of new value doesn\'t fit into type ' + registerObj.type + ': ' + value);
+  }
+
+  this.debug('Sending ' + buf.length + ' bytes for register ' + registerObj.registerHex + ': ' + buf.toString('hex'));
+  try {
+    if (registerObj.register >= 0) {
+      this.i2cAdapter.bus.writeI2cBlockSync(this.address, registerObj.register, buf.length, buf);
+    } else {
+      this.i2cAdapter.bus.i2cWriteSync(this.address, buf.length, buf);
+    }
+    this.setStateAck(registerObj, value);
+  } catch (e) {
+    this.error('Couldn\'t send value: ' + e);
+  }
+};
+
+Generic.prototype.initPolling = function (registerObj) {
+  var that = this;
+  that.timers.push(setInterval(function () {
+    that.poll(registerObj);
+  }, Math.max(50, registerObj.pollingInterval)));
+};
+
+Generic.prototype.poll = function (registerObj) {
+  this.debug('Reding from register ' + registerObj.registerHex);
+
+  var buf;
+  switch (registerObj.type) {
+    case 'int8':
+      buf = Buffer.alloc(1);
+      break;
+    case 'uint8':
+      buf = Buffer.alloc(1);
+      break;
+    case 'int16_be':
+      buf = Buffer.alloc(2);
+      break;
+    case 'int16_le':
+      buf = Buffer.alloc(2);
+      break;
+    case 'uint16_be':
+      buf = Buffer.alloc(2);
+      break;
+    case 'uint16_le':
+      buf = Buffer.alloc(2);
+      break;
+    case 'int32_be':
+      buf = Buffer.alloc(4);
+      break;
+    case 'int32_le':
+      buf = Buffer.alloc(4);
+      break;
+    case 'uint32_be':
+      buf = Buffer.alloc(4);
+      break;
+    case 'uint32_le':
+      buf = Buffer.alloc(4);
+      break;
+    case 'float_be':
+      buf = Buffer.alloc(4);
+      break;
+    case 'float_le':
+      buf = Buffer.alloc(4);
+      break;
+    case 'double_be':
+      buf = Buffer.alloc(8);
+      break;
+    case 'double_le':
+      buf = Buffer.alloc(8);
+      break;
+    default:
+      this.error('Couldn\'t read value because of unknown type: ' + registerObj.type);
+      return;
+  }
+
+  // read raw data from bus
+  try {
+    if (registerObj.register >= 0) {
+      this.i2cAdapter.bus.readI2cBlockSync(this.address, registerObj.register, buf.length, buf);
+    } else {
+      this.i2cAdapter.bus.i2cReadSync(this.address, buf.length, buf);
+    }
+  } catch (e) {
+    this.error('Couldn\'t read value: ' + e);
+    return;
+  }
+
+  // parse data to data type
+  var value;
+  try {
+    switch (registerObj.type) {
+      case 'int8':
+        value = buf.readInt8();
+        break;
+      case 'uint8':
+        value = buf.readUInt8();
+        break;
+      case 'int16_be':
+        value = buf.readInt16BE();
+        break;
+      case 'int16_le':
+        value = buf.readInt16LE();
+        break;
+      case 'uint16_be':
+        value = buf.readUInt16BE();
+        break;
+      case 'uint16_le':
+        value = buf.readUInt16LE();
+        break;
+      case 'int32_be':
+        value = buf.readInt32BE();
+        break;
+      case 'int32_le':
+        value = buf.readInt32LE();
+        break;
+      case 'uint32_be':
+        value = buf.readUInt32BE();
+        break;
+      case 'uint32_le':
+        value = buf.readUInt32LE();
+        break;
+      case 'float_be':
+        value = buf.readFloatBE();
+        break;
+      case 'float_le':
+        value = buf.readFloatLE();
+        break;
+      case 'double_be':
+        value = buf.readDoubleBE();
+        break;
+      case 'double_le':
+        value = buf.readDoubleLE();
+        break;
+    }
+
+    this.debug('Read ' + buf.toString('hex') + ' -> ' + value);
+  } catch (e) {
+    this.error('Couldn\'t read value as type ' + registerObj.type + ' from buffer ' + buf.toString('hex') + ': ' + e);
+    return;
+  }
+
+  // save the value into the state
+  this.setStateAck(registerObj, value);
+};
+
+Generic.prototype.debug = function (message) {
+  this.adapter.log.debug('Generic ' + this.address + ': ' + message);
+};
+
+Generic.prototype.error = function (message) {
+  this.adapter.log.error('Generic ' + this.address + ': ' + message);
+};
+
+Generic.prototype.setStateAck = function (registerObj, value) {
+  return this.i2cAdapter.setStateAck(this.hexAddress + '.' + registerObj.registerHex, value);
+};
+
+Generic.prototype.getStateValue = function (registerObj) {
+  return this.i2cAdapter.getStateValue(this.hexAddress + '.' + registerObj.registerHex);
+};
+
+module.exports.create = create;

--- a/devices/MCP23017.js
+++ b/devices/MCP23017.js
@@ -26,7 +26,7 @@ function MCP23017(deviceConfig, i2cAdapter) {
 
     this.i2cAdapter = i2cAdapter;
     this.adapter = this.i2cAdapter.adapter;
-    
+
     this.initialized = false;
     this.hasInput = false;
     this.directions = 0;
@@ -47,7 +47,7 @@ MCP23017.prototype.start = function () {
         },
         native: that.config
     });
-    
+
     for (var i = 0; i < 16; i++) {
         var pinConfig = that.config.pins[i] || { dir: 'out', name: that.indexToName(i) };
         var isInput = pinConfig.dir != 'out';
@@ -86,13 +86,33 @@ MCP23017.prototype.start = function () {
             native: pinConfig
         });
     }
-    
+
     that.checkInitialized();
 
     if (that.hasInput && that.config.pollingInterval && parseInt(that.config.pollingInterval) > 0) {
         this.pollingTimer = setInterval(
             function () { that.readCurrentValue(false); },
             Math.max(50, parseInt(that.config.pollingInterval)));
+        that.debug('Polling enabled (' + parseInt(that.config.pollingInterval) + ' ms)');
+    }
+
+    if (that.hasInput && typeof that.config.interrupt === 'string' && that.config.interrupt.length > 0) {
+        // check if interrupt object exists
+        that.adapter.getObject(that.config.interrupt, function(err, obj) {
+            if (err) {
+                that.warn('Interrupt object ' + that.config.interrupt + ' not found!');
+                return;
+            }
+
+            // subscribe to the object and add change listener
+            that.adapter.subscribeForeignStates(that.config.interrupt);
+            that.i2cAdapter.addForeignStateChangeListener(that.config.interrupt, function (state) {
+                that.debug('Interrupt detected');
+                that.readCurrentValue(false);
+            });
+
+            that.debug('Interrupt enabled');
+        });
     }
 };
 
@@ -112,7 +132,7 @@ MCP23017.prototype.checkInitialized = function () {
         this.error("GPIO directions unexpectedly changed, reconfiguring the device");
         this.initialized = false;
     }
-    
+
     try {
         this.debug('Setting initial output value to ' + this.i2cAdapter.toHexString(this.writeValue, 4));
         this.writeWord(REG_OLAT, this.writeValue);
@@ -127,7 +147,7 @@ MCP23017.prototype.checkInitialized = function () {
         this.error("Couldn't initialize: " + e);
         return false;
     }
-    
+
     this.readCurrentValue(true);
     return this.initialized;
 };
@@ -165,7 +185,7 @@ MCP23017.prototype.readCurrentValue = function (force) {
     if (oldValue == this.readValue && !force) {
         return;
     }
-    
+
     this.debug('Read ' + this.i2cAdapter.toHexString(this.readValue, 4));
     for (var i = 0; i < 16; i++) {
         var mask = 1 << i;

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "i2c",
-        "version": "0.0.6",
+        "version": "0.0.8",
         "news": {
             "0.0.1": {
                 "en": "initial version",
@@ -26,6 +26,14 @@
             "0.0.6": {
                 "en": "Added support for ADS1015, ADS1115 and BME280.",
                 "de": "Unterstüztung für ADS1015, ADS1115 und BME280 hinzugefügt."
+            },
+            "0.0.7": {
+                "en": "Added support for interrupts on PCF8574, MCP23008, MCP23017 devices.",
+                "de": "Unterstüztung für Interrupts bei PCF8574, MCP23008, MCP23017 hinzugefügt."
+            },
+            "0.0.8": {
+                "en": "Added support for Generic device. Added support for `read` and `write` commands in scripts using `sendTo`.",
+                "de": "Unterstüztung für Allgemeine Geräte hinzugefügt. Unterstüztung für `read` und `write` Befehle in Skripten über `sendTo` hinzugefügt."
             }
         },
         "title": "I2C Adapter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.i2c",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "description": "Adapter for ioBroker that communicates with devices over I2C bus",
   "main": "i2c.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     {
       "name": "UncleSamSwiss",
       "email": "samuel.weibel@gmail.com"
+    },
+    {
+      "name": "Peter Müller",
+      "email": "peter@crycode.de"
     }
   ],
   "license": "Apache-2.0",


### PR DESCRIPTION
Hi,

I've implemented the use of interrupts for PCF8574 and MCP230xx. (Tested only with PCF8574 but should work with MCP230xx too.)
In the config dialog you can now select an object for the interrupt. When the state of this object changes, `readCurrentValue` is called as in the polling interval.

Additionally I've fixed a small bug with the input direction of the PCF8574.
To use a pin as an input, this pin must set to high level. Then the pin can be externally pulled low, e.g. by a button directly to ground.