### PR TITLE
Fixed text colors in admin 5 dark themes

### DIFF
--- a/admin/src/app.tsx
+++ b/admin/src/app.tsx
@@ -45,13 +45,15 @@ class App extends GenericApp {
             return super.render();
         }
 
+        const { theme } = this.state;
+
         const context: AppContext = {
             socket: this.socket,
             instanceId: this.instanceId,
         };
 
         return (
-            <div className="App">
+            <div className="App" style={{ background: theme.palette.background.default, color: theme.palette.text.primary }}>
                 <Settings
                     native={this.state.native}
                     context={context}

--- a/admin/src/app.tsx
+++ b/admin/src/app.tsx
@@ -53,7 +53,10 @@ class App extends GenericApp {
         };
 
         return (
-            <div className="App" style={{ background: theme.palette.background.default, color: theme.palette.text.primary }}>
+            <div
+                className="App"
+                style={{ background: theme.palette.background.default, color: theme.palette.text.primary }}
+            >
                 <Settings
                     native={this.state.native}
                     context={context}


### PR DESCRIPTION
When a dark theme is used in admin 5, most texts are shown in black and therefore they are not readable.
This small change adds the missing styles to the "App" div to use the correct `background` and `color` values for each theme.